### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-bcmath": "*"
     },
     "autoload": {
         "psr-4": {"ShortCode\\": "src/ShortCode"}


### PR DESCRIPTION
On PHP 7, `bcmath` extension is not bundled and has to be installed i.e. `sudo apt install php7.0-bcmath`
Since this wasn't required in `composer.json` my production server was throwing errors about missing extension after installing this package.